### PR TITLE
Fixed Authorization filter.

### DIFF
--- a/src/main/java/pl/szmidla/chatappbackend/security/MyAuthorizationFilter.java
+++ b/src/main/java/pl/szmidla/chatappbackend/security/MyAuthorizationFilter.java
@@ -3,11 +3,11 @@ package pl.szmidla.chatappbackend.security;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import pl.szmidla.chatappbackend.config.PropertiesConfig;
@@ -57,7 +57,7 @@ public class MyAuthorizationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                     filterChain.doFilter(request, response);
                 }
-                catch (Exception exception) {
+                catch (JWTVerificationException exception) {
                     log.error("Error logging in: {}", exception.getMessage());
                     response.setStatus(UNAUTHORIZED.value());
 


### PR DESCRIPTION
Fixed Authorization filter. It was giving 401 status code when some exceptions were thrown and that was in fact confussing. Now 401 status is set only if the catched exception in the filter is because of some problems with JWT