### PR TITLE
PR, Implemented way to see if message was read

### DIFF
--- a/src/main/java/pl/szmidla/chatappbackend/api/ChatApi.java
+++ b/src/main/java/pl/szmidla/chatappbackend/api/ChatApi.java
@@ -52,4 +52,11 @@ public class ChatApi {
         chatService.sendMessage(user, chatId, content);
         return true;
     }
+
+    @PostMapping(value = "/{id}/message-read")
+    public void messageRead(@PathVariable("id") long chatId,
+                               @RequestParam long messageId) {
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        chatService.messageRead(user, chatId, messageId);
+    }
 }

--- a/src/main/java/pl/szmidla/chatappbackend/data/Chat.java
+++ b/src/main/java/pl/szmidla/chatappbackend/data/Chat.java
@@ -3,6 +3,7 @@ package pl.szmidla.chatappbackend.data;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 
 import lombok.*;
 
@@ -29,6 +30,14 @@ public class Chat extends BaseEntity {
     private String lastMessage;
     /** last message's date or date of creation the chat */
     private LocalDateTime lastDate;
+
+    @OneToOne
+    @JoinColumn(name = "last_message_read_by_user1_id")
+    private Message lastReadByUser1;
+
+    @OneToOne
+    @JoinColumn(name = "last_message_read_by_user2_id")
+    private Message lastReadByUser2;
 
     private boolean closed;
 }

--- a/src/main/java/pl/szmidla/chatappbackend/data/dto/ChatPreview.java
+++ b/src/main/java/pl/szmidla/chatappbackend/data/dto/ChatPreview.java
@@ -20,14 +20,27 @@ public class ChatPreview {
     private String usersImageUrl;
     private Long firstMessageId;
     private String message; // last message
+    private long lastReadMessageIdByThis;
+    private long lastReadMessageIdByOther;
     private String lastInteractionDate; // date of last message or creation time    LocalDateTime.toString()
     private String lastActiveDate; // date of last activity / null if active now
 
-    public static ChatPreview fromChat(Chat chat, User receiver) {
-        User userToBeInChat = chat.getUser1().equals(receiver) ? chat.getUser2() : chat.getUser1();
+    public static ChatPreview fromChat(Chat chat, User logged) {
+        User userToBeInChat = chat.getUser1().equals(logged) ? chat.getUser2() : chat.getUser1();
         String messageContent = chat.getLastMessage();
         String lastActiveDateString = userToBeInChat.getLastActive() != null ?
                 userToBeInChat.getLastActive().toString() : null;
+        long lastReadMessageIdByThis;
+        long lastReadMessageIdByOther;
+        if (logged.equals(chat.getUser1())) {
+            lastReadMessageIdByThis = chat.getLastReadByUser1() == null ? 0 : chat.getLastReadByUser1().getId();
+            lastReadMessageIdByOther = chat.getLastReadByUser2() == null ? 0 : chat.getLastReadByUser2().getId();
+        }
+        else {
+            lastReadMessageIdByThis = chat.getLastReadByUser2() == null ? 0 : chat.getLastReadByUser2().getId();
+            lastReadMessageIdByOther = chat.getLastReadByUser1() == null ? 0 : chat.getLastReadByUser1().getId();
+        }
+
         return new ChatPreview(
                 chat.getId(),
                 userToBeInChat.getId(),
@@ -35,6 +48,8 @@ public class ChatPreview {
                 userToBeInChat.getImageUrl(),
                 chat.getFirstMessageId(),
                 messageContent,
+                lastReadMessageIdByThis,
+                lastReadMessageIdByOther,
                 chat.getLastDate().toString(),
                 lastActiveDateString
         );

--- a/src/main/java/pl/szmidla/chatappbackend/repository/MessageRepository.java
+++ b/src/main/java/pl/szmidla/chatappbackend/repository/MessageRepository.java
@@ -8,14 +8,17 @@ import org.springframework.stereotype.Repository;
 import pl.szmidla.chatappbackend.data.Message;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
+    Optional<Message> findById(long id);
+
     @Query("""
         SELECT m FROM Message m
         LEFT JOIN m.chat as c
-        WHERE c.id = :id AND 
+        WHERE c.id = :id AND
               m.id < :lastMessageId
         ORDER BY m.date DESC
     """)

--- a/src/main/java/pl/szmidla/chatappbackend/service/MessageService.java
+++ b/src/main/java/pl/szmidla/chatappbackend/service/MessageService.java
@@ -1,0 +1,49 @@
+package pl.szmidla.chatappbackend.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import pl.szmidla.chatappbackend.data.Chat;
+import pl.szmidla.chatappbackend.data.Message;
+import pl.szmidla.chatappbackend.exception.ItemNotFoundException;
+import pl.szmidla.chatappbackend.repository.MessageRepository;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class MessageService {
+
+    private MessageRepository messageRepository;
+
+    public Message getMessageById(long id) {
+        return messageRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.error("Message with id={} not found", id);
+                    return new ItemNotFoundException("message");
+                });
+    }
+
+    public Message getMessageByIdWithinChat(long messageId, Chat chat) {
+        Message message = getMessageById(messageId);
+        if (!message.getChat().equals(chat)) {
+            log.error("Message with id={} is not in chat with id={}", messageId, chat.getId());
+            throw new IllegalArgumentException("Message now within a chat");
+        }
+        return message;
+    }
+
+    public List<Message> getLastNMessagesFromChat(long chatId, Pageable pageable) {
+        return messageRepository.findLastNMessagesFromChat(chatId, pageable);
+    }
+
+    public List<Message> getLastNMessagesFromChatAfterId(long chatId, long lastMessageId, Pageable pageable) {
+        return messageRepository.findLastNMessagesFromChatAfterId(chatId, lastMessageId, pageable);
+    }
+
+    public void saveMessage(Message message) {
+        messageRepository.save(message);
+    }
+}

--- a/src/test/java/pl/szmidla/chatappbackend/api/ChatApiTest.java
+++ b/src/test/java/pl/szmidla/chatappbackend/api/ChatApiTest.java
@@ -190,4 +190,14 @@ class ChatApiTest {
 
         assertEquals( expectedJson, responseJson );
     }
+
+    @Test
+    void messageRead() throws Exception {
+        long chatId = 1L;
+        long messageId = 1L;
+
+        mockMvc.perform( post("/api/chats/{id}/message-read", chatId)
+                        .param("messageId", String.valueOf(messageId) ) )
+                .andExpect( status().isOk() );
+    }
 }

--- a/src/test/java/pl/szmidla/chatappbackend/service/MessageServiceTest.java
+++ b/src/test/java/pl/szmidla/chatappbackend/service/MessageServiceTest.java
@@ -1,0 +1,152 @@
+package pl.szmidla.chatappbackend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import pl.szmidla.chatappbackend.data.Chat;
+import pl.szmidla.chatappbackend.data.Message;
+import pl.szmidla.chatappbackend.data.User;
+import pl.szmidla.chatappbackend.exception.ItemNotFoundException;
+import pl.szmidla.chatappbackend.repository.MessageRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessageServiceTest {
+
+    @Mock
+    MessageRepository messageRepository;
+    @InjectMocks
+    MessageService messageService;
+
+    User user1;
+    User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = createUser(1L, "user1", "em1@o2.com", "password");
+        user2 = createUser(2L, "user2", "some@em.com", "passw");
+    }
+
+
+    private User createUser(long id, String username, String email, String password) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPassword(password);
+        return user;
+    }
+
+    @Test
+    void getMessageById() {
+        Chat chat = createChat(1L, user1, user2, null);
+        Message expectedMessage = createMessageNow(1L, "content", true, chat);
+        when( messageRepository.findById(anyLong()) ).thenReturn( Optional.of(expectedMessage) );
+
+        Message actualMessage = messageService.getMessageById(expectedMessage.getId());
+
+        assertEquals( expectedMessage, actualMessage );
+    }
+
+    Chat createChat(long id, User thisUser, User otherUser, Message lastMessage) {
+        Chat chat = new Chat();
+        chat.setId(id);
+        chat.setUser1(thisUser);
+        chat.setUser2(otherUser);
+
+        if (lastMessage != null) {
+            lastMessage.setChat(chat);
+        }
+        return chat;
+    }
+
+    Message createMessageNow(long id, String content, boolean byUser1, Chat chat) {
+        Message message = Message.builder()
+                .content(content)
+                .byUser1(byUser1)
+                .date(LocalDateTime.now())
+                .chat(chat).build();
+        message.setId(id);
+        chat.setLastMessage(message.getContent());
+        chat.setLastDate(message.getDate());
+        return message;
+    }
+
+    @Test
+    void getMessageByIdException() {
+        when( messageRepository.findById(anyLong()) ).thenReturn( Optional.empty() );
+
+        Throwable exception = assertThrows(ItemNotFoundException.class, () ->
+                messageService.getMessageById(anyLong()));
+
+        assertEquals( ItemNotFoundException.MESSAGE_TEMPLATE.formatted("Message"), exception.getMessage() );
+    }
+
+    @Test
+    void getMessageByIdWithinChat() {
+        Chat chat = createChat(1L, user1, user2, null);
+        Message expectedMessage = createMessageNow(1L, "content", true, chat);
+        when( messageRepository.findById(anyLong()) ).thenReturn( Optional.of(expectedMessage) );
+
+        Message actualMessage = messageService.getMessageByIdWithinChat(expectedMessage.getId(), chat);
+
+        assertEquals( expectedMessage, actualMessage );
+    }
+
+    @Test
+    void getMessageByIdWithinChatException() {
+        Chat chat1 = createChat(1L, user1, user2, null);
+        Chat chat2 = createChat(2L, user1, user2, null);
+        Message message = createMessageNow(1L, "content", true, chat1);
+        when( messageRepository.findById(anyLong()) ).thenReturn( Optional.of(message) );
+
+        assertThrows( IllegalArgumentException.class, () ->
+                messageService.getMessageByIdWithinChat(message.getId(), chat2));
+    }
+
+    @Test
+    void getLastNMessagesFromChat() {
+        Chat chat = createChat(1L, user1, user2, null);
+        List<Message> expectedMessages = List.of( createMessageNow(1L, "hello", true, chat) );
+        PageRequest pageable = PageRequest.of(0, 1);
+        when( messageRepository.findLastNMessagesFromChat(anyLong(), any()) ).thenReturn( expectedMessages );
+
+        List<Message> actualMessages = messageService.getLastNMessagesFromChat(chat.getId(), pageable);
+
+        assertEquals( expectedMessages, actualMessages );
+    }
+
+    @Test
+    void getLastNMessagesFromChatAfterId() {
+        Chat chat = createChat(1L, user1, user2, null);
+        long paramId = 1L;
+        List<Message> expectedMessages = List.of( createMessageNow(2L, "hello", true, chat) );
+        PageRequest pageable = PageRequest.of(0, 1);
+        when( messageRepository.findLastNMessagesFromChatAfterId(anyLong(), anyLong(),any()) ).thenReturn( expectedMessages );
+
+        List<Message> actualMessages = messageService.getLastNMessagesFromChatAfterId(chat.getId(), paramId, pageable);
+
+        assertEquals( expectedMessages, actualMessages );
+    }
+
+    @Test
+    void saveMessage() {
+        Chat chat = createChat(1L, user1, user2, null);
+        Message message = createMessageNow(2L, "hello", true, chat);
+
+        messageService.saveMessage(message);
+    }
+}

--- a/src/test/java/pl/szmidla/chatappbackend/service/UserServiceTest.java
+++ b/src/test/java/pl/szmidla/chatappbackend/service/UserServiceTest.java
@@ -168,7 +168,7 @@ class UserServiceTest {
 
         Throwable exception = assertThrows(ItemNotFoundException.class, () -> userService.getUserById(user.getId()));
 
-        assertEquals( ItemNotFoundException.MESSAGE_TEMPLATE.formatted("Uqqser"), exception.getMessage() );
+        assertEquals( ItemNotFoundException.MESSAGE_TEMPLATE.formatted("User"), exception.getMessage() );
     }
 
     @Test


### PR DESCRIPTION
Added last read message by users to chat, so know it's possible to track up to which messages have the users read the chat.

The last read message changes for sender if they send a new message. It also gets updated while getting new messages by getNMessagesFromChat and by POST request to the /api/chats/{id}/message-read. This last option is for messages loaded through WebSocket connection.